### PR TITLE
fix: solve loss context problem

### DIFF
--- a/src/pages/employee/Employee.jsx
+++ b/src/pages/employee/Employee.jsx
@@ -8,13 +8,14 @@ export default class Employee extends React.PureComponent {
     this.state = {
       isOpen: false,
     };
+    this.openSidebar = this.openSidebar.bind(this);
   }
 
-  openSidebar = () => {
+  openSidebar() {
     this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
-  };
+  }
 
   render() {
     const { isOpen } = this.state;


### PR DESCRIPTION
Prevented the use of an arrow function in the class. The function context binding was added to the class constructor using the bind function.